### PR TITLE
add network_3d function and delete gsub line

### DIFF
--- a/R/naverRelation.R
+++ b/R/naverRelation.R
@@ -51,7 +51,6 @@ naverRelation2 <- function(x){
   for(i in html) html2[[i]] <- naverRelation1(i)
 
   res <- html2 %>%
-    lapply(FUN = function(x) gsub(paste0("\\b", x, "\\b", "|", "^", x, " ", "| ", x, "$"), "", x = x)) %>%
     melt %>%
     select(R1 = L1, R2 = value) %>%
     dplyr::filter(R2 != "") %>%

--- a/R/networkplot_3d.R
+++ b/R/networkplot_3d.R
@@ -1,0 +1,29 @@
+#' Network plot about preprocessed naverRelation2 result
+#'
+#' Network plot about preprocessed naverRelation2 result
+#' @param x return to \code{naverRelation2()} object
+#' @export
+#' @examples
+#' networkPlot(naverRelation2("korea"))
+
+  networkplot_3d <- function(x){
+    
+    stopifnot(require(igraph), require(ggraph))
+    
+    pre <- x %>%
+      count(R2, R1) %>%
+      graph_from_data_frame %>%
+      igraph_to_networkD3
+    
+    pre$nodes$group <- as.factor(1:nrow(pre$nodes))
+    
+    return(
+      
+      forceNetwork(Links = pre$links, Nodes = pre$nodes,
+                   Source = "source", Target = "target",
+                   Value = "value", NodeID = "name",
+                   Group = "group", opacity = 0.8, zoom = T, fontSize = 20)
+      
+    )
+
+  }


### PR DESCRIPTION
1. 2차연관검색어 함수 내의 gsub코드 삭제
-상위 연관검색어의 삭제 필요성은 있으나 일괄 삭제는 문제가 있을 것으로 판단되어 보류.

2. network_3d 함수 추가
-2차 연관검색어 결과물을 networkD3 패키지의 forceNetwork 함수를 이용하여 표현할 수 있도록 베이스코드 생성
-현재는 노드의 그룹등을 임의로 설정하였으나 추후 논리적으로 부여하는 방안 논의 필요
-우선 표현만 가능하도록 생성.