### PR TITLE
V0.2.3

### DIFF
--- a/R/saveToDB.R
+++ b/R/saveToDB.R
@@ -1,7 +1,7 @@
 #' Save and Load relation search words to sqlite
 #'
 #' Save and Load relation search words to sqlite
-#' @param x return to \code{naverRelation2()} object
+#' @param x return to \code{naverRelation()} object
 #' @param path save fileDB path
 #' @export
 #' @examples
@@ -11,7 +11,7 @@
 
 saveHistory <- function(x, path = "nvrHistory.sqlite"){
 
-  stopifnot(require(RSQLite))
+  stopifnot(require(RSQLite), require(dplyr))
 
   time <- Sys.time() %>%
     format(format = "%Y%m%d%H%M%S") %>%
@@ -33,14 +33,14 @@ saveHistory <- function(x, path = "nvrHistory.sqlite"){
 
 loadHistory <- function(){
 
-  stopifnot(require(RSQLite))
+  stopifnot(require(RSQLite), require(dplyr))
 
   con <- dbConnect(SQLite(), "nvrHistory.sqlite")
   res <- dbGetQuery(con, "select * from nvrHistory") %>% tbl_df
   dbDisconnect(con)
 
   class(res) <- class(res) %>% append("nr", after = 0)
-  attr(res, "depth") <- max(res$depth)
+  attr(res, "depth") <- grep("R[^0]", colnames(res)) %>% length
   return(res)
 
 }


### PR DESCRIPTION
1. saveToDB 파일에 있는 파라미터 설명에서 기 삭제된 naverRelation2()함수를 naverRelation()로 변경.

2. stopifnot() 내부 인자로 사용된 인자들을 require(RSQLite), require(dplyr)로 변경.
함수 내부에 체인 연산자(%>%)를 사용하였으나 패키지가 로드되어 있지 않은 경우에도 멈추게 하지 않아 오류 발생.  `saveHistory()`, `loadHistory()` 함수에 모두 적용.

3. `loadHistory()` 함수의 `res` 오브젝트 속성부여 과정에서 'res$depth'가 존재하지 않아 `-Inf`값으로 `depth` 속성부여가 됨. 따라서 Rx 형태로 부여되는 변수명에 착안하여 정규표현식을 이용한 `depth` 속성부여 코드 추가. 추후 3차 이상의 연관검색어 자료를 고려한 코드로 키워드인 R0 열을 제외한 Rx 열의 수만큼 `depth`를 부여하도록 함.

테스트는 금번 회의때 은광님께서 제공해주신 `nvrHistory.sqlite` 파일을 이용함.
오류 여부 정확히 파악 후 병합 바람.
